### PR TITLE
fix: disable keep-alive connections for notarization and metrics server

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -42,6 +42,10 @@ func main() {
 	// 5. Create HTTP server
 	notarizationServer, metricsServer := server.NewServer()
 
+	// Disable keep-alive to prevent connection reuse
+	notarizationServer.SetKeepAlivesEnabled(false)
+	metricsServer.SetKeepAlivesEnabled(false)
+
 	// Create a channel to listen for server errors
 	serverErr := make(chan error, 2)
 


### PR DESCRIPTION
- Fixes #9 